### PR TITLE
Keep track of the `TESQuestTarget` for which each marker was created

### DIFF
--- a/include/FocusedMarker.h
+++ b/include/FocusedMarker.h
@@ -36,7 +36,19 @@ struct FocusedMarker
 		{
 			if (settings::display::showObjectiveAsTarget)
 			{
+				if (objectives.size() == 1) {
 				return objectives.back();
+				} else {
+					static std::string markerText;
+					markerText.clear();
+					for (int i = 0; i < objectives.size(); i++) {
+						if (i > 0) {
+							markerText.append(", ");
+						}
+						markerText.append(objectives[i]);
+					}
+					return markerText;
+				}
 			}
 			else
 			{

--- a/include/HUDMarkerManager.h
+++ b/include/HUDMarkerManager.h
@@ -21,8 +21,8 @@ namespace extended
 			return &singleton;
 		}
 
-		void ProcessQuestMarker(RE::TESQuest* a_quest, RE::BGSInstancedQuestObjective &a_objective, RE::TESObjectREFR* a_marker,
-								std::uint32_t a_markerGotoFrame);
+		void ProcessQuestMarker(RE::TESQuest* a_quest, RE::BGSInstancedQuestObjective &a_objective, RE::TESQuestTarget* a_target,
+								RE::TESObjectREFR* a_marker, std::uint32_t a_markerGotoFrame);
 
 		void ProcessLocationMarker(RE::ExtraMapMarker* a_mapMarker, RE::TESObjectREFR* a_marker,
 								   std::uint32_t a_markerGotoFrame);

--- a/include/HUDMarkerManager.h
+++ b/include/HUDMarkerManager.h
@@ -21,7 +21,7 @@ namespace extended
 			return &singleton;
 		}
 
-		void ProcessQuestMarker(RE::TESQuest* a_quest, RE::TESObjectREFR* a_marker,
+		void ProcessQuestMarker(RE::TESQuest* a_quest, RE::BGSInstancedQuestObjective &a_objective, RE::TESObjectREFR* a_marker,
 								std::uint32_t a_markerGotoFrame);
 
 		void ProcessLocationMarker(RE::ExtraMapMarker* a_mapMarker, RE::TESObjectREFR* a_marker,

--- a/include/Hooks.h
+++ b/include/Hooks.h
@@ -18,7 +18,7 @@ namespace hooks
 	public:
 
 		static inline REL::Relocation<bool (*)(const RE::HUDMarkerManager*, RE::TESQuest**,
-											   RE::BSTArray<RE::UnkValue>*)> UpdateQuests{ UpdateQuestsId };
+			RE::BSTArray<RE::TESQuestTarget>*)> UpdateQuests{ UpdateQuestsId };
 
 		static inline REL::Relocation<bool (*)(const RE::HUDMarkerManager*)> UpdateLocations{ UpdateLocationsId };
 
@@ -48,7 +48,7 @@ namespace hooks
 
 	bool UpdateQuests(const RE::HUDMarkerManager* a_hudMarkerManager, RE::HUDMarker::ScaleformData* a_markerData,
 							RE::NiPoint3* a_pos, const RE::RefHandle& a_refHandle, std::uint32_t a_markerGotoFrame,
-							RE::TESQuest*& a_quest);
+		RE::TESQuestTarget* a_questTargets);
 
 	RE::TESWorldSpace* AllowedToShowMapMarker(const RE::TESObjectREFR* a_marker);
 
@@ -78,7 +78,11 @@ namespace hooks
 					Xbyak::Label hookLabel;
 					Xbyak::Label retnLabel;
 
-					mov(ptr[rsp + 0x28], REL::Module::IsSE() ? r14 : rdi);	// SE: r14, AE: rdi = TESQuest**
+					//There's not enough room for both of these, as rsp+0x30 is in use, but we can deduce the quest
+					// from the quest target
+
+					//mov(ptr[rsp + 0x28], REL::Module::IsSE() ? r14 : rdi);	// SE: r14, AE: rdi = TESQuest**
+					mov(ptr[rsp + 0x28], rbx);	// TESQuestTarget*
 					call(ptr[rip + hookLabel]);
 
 					jmp(ptr[rip + retnLabel]);

--- a/source/HUDMarkerManager.cpp
+++ b/source/HUDMarkerManager.cpp
@@ -62,7 +62,7 @@ namespace extended
 
 			// Add objectives to the quest data. The objectives are in oldest-to-newest order,
 			// so we iterate from newest-to-oldest to have it in the same order as in the journal
-			for (int i = player->objectives.size() - 1; i >= 0; i--) {
+			for (int i = player->GetPlayerRuntimeData().objectives.size() - 1; i >= 0; i--) {
 				const RE::BGSInstancedQuestObjective& instancedObjective = player->objectives[i];
 
 				bool objectiveHasTarget = false;

--- a/source/HUDMarkerManager.cpp
+++ b/source/HUDMarkerManager.cpp
@@ -14,7 +14,7 @@ namespace extended
 		RE::NiPoint3 targetPosition;
 	};
 
-	void HUDMarkerManager::ProcessQuestMarker(RE::TESQuest* a_quest, RE::TESObjectREFR* a_marker,
+	void HUDMarkerManager::ProcessQuestMarker(RE::TESQuest* a_quest, RE::BGSInstancedQuestObjective &a_instancedObjective, RE::TESObjectREFR* a_marker,
 											  std::uint32_t a_markerGotoFrame)
 	{
 		float angleToPlayerCamera = GetAngleBetween(playerCamera, a_marker);
@@ -60,68 +60,9 @@ namespace extended
 				facedMarker->data.push_back(questData);
 			}
 
-			// Add objectives to the quest data. The objectives are in oldest-to-newest order,
-			// so we iterate from newest-to-oldest to have it in the same order as in the journal
-			for (int i = player->objectives.size() - 1; i >= 0; i--)
-			{
-				const RE::BGSInstancedQuestObjective& instancedObjective = player->objectives[i];
-
-				if (instancedObjective.objective->ownerQuest == a_quest &&
-					instancedObjective.instanceState == RE::QUEST_OBJECTIVE_STATE::kDisplayed)
-				{
-					// Add each objective only once per quest
-					if (std::ranges::find(questData->addedInstancedObjectives, &instancedObjective) == questData->addedInstancedObjectives.end()) 
-					{
-						if (questData->ageIndex == -1)
-						{
-							questData->ageIndex = i;
-						}
-
-						// If the marker points to a portal
-						if (auto teleportLinkedDoor = a_marker->extraList.GetTeleportLinkedDoor().get()) 
-						{
-							questData->addedInstancedObjectives.push_back(&instancedObjective);
-							questData->objectives.push_back(instancedObjective.GetDisplayTextWithReplacedTags().c_str());
-						}
-						else
-						{
-							for (int j = 0; j < instancedObjective.objective->numTargets; j++)
-							{
-								auto questTargetEx = reinterpret_cast<extended::QuestTarget*>(instancedObjective.objective->targets[j]);
-
-								if (questTargetEx->targetPosition == a_marker->data.location)
-								{
-									questData->addedInstancedObjectives.push_back(&instancedObjective);
-									questData->objectives.push_back(instancedObjective.GetDisplayTextWithReplacedTags().c_str());
-									break;
-								}
-							}
-						}
-					}
-				}
-			}
-			if (questData->addedInstancedObjectives.empty())
-			{
-				for (int i = player->objectives.size() - 1; i >= 0; i--)
-				{
-					const RE::BGSInstancedQuestObjective& instancedObjective = player->objectives[i];
-
-					if (instancedObjective.objective->ownerQuest == a_quest &&
-						instancedObjective.instanceState == RE::QUEST_OBJECTIVE_STATE::kDisplayed) 
-					{
-						// Add each objective only once per quest
-						if (std::ranges::find(questData->addedInstancedObjectives, &instancedObjective) == questData->addedInstancedObjectives.end())
-						{
-							if (questData->ageIndex == -1)
-							{
-								questData->ageIndex = i;
-							}
-
-							questData->addedInstancedObjectives.push_back(&instancedObjective);
-							questData->objectives.push_back(instancedObjective.GetDisplayTextWithReplacedTags().c_str());
-						}
-					}
-				}
+			if (std::ranges::find(questData->addedInstancedObjectives, &a_instancedObjective) == questData->addedInstancedObjectives.end()) {
+				questData->addedInstancedObjectives.push_back(&a_instancedObjective);
+				questData->objectives.push_back(a_instancedObjective.GetDisplayTextWithReplacedTags().c_str());
 			}
 		}
 	}

--- a/source/Hooks.cpp
+++ b/source/Hooks.cpp
@@ -11,6 +11,13 @@ namespace hooks
 		RE::TESQuestTarget* a_questTarget)
 	{
 		//
+		// The game loops through active quest targets, and calls `AddMarker` for each one.
+		// If multiple targets correspond to the same marker, `AddMarker` returns the 
+		// previously-created marker (via `a_refHandle`), so we can iteratively
+		// build the structure containing all the targets, objectives, etc. corresponding
+		// to the marker.
+		// 
+
 		if (HUDMarkerManager::AddMarker(a_hudMarkerManager, a_markerData, a_pos, a_refHandle, a_markerGotoFrame))
 		{
 			RE::TESObjectREFR* marker = RE::TESObjectREFR::LookupByHandle(a_refHandle).get();

--- a/source/Hooks.cpp
+++ b/source/Hooks.cpp
@@ -26,11 +26,11 @@ namespace hooks
 			RE::TESQuest* quest;
 			RE::BGSInstancedQuestObjective objective;
 			RE::TESQuestTarget* target;
-			for (int i = 0; i < player->objectives.size(); i++) {
-				for (int j = 0; j < player->objectives[i].objective->numTargets; j++) {
-					if (a_questTarget->unk00 == (uint64_t)player->objectives[i].objective->targets[j]) {
-						quest = player->objectives[i].objective->ownerQuest;
-						objective = player->objectives[i];
+			for (int i = 0; i < player->GetPlayerRuntimeData().objectives.size(); i++) {
+				for (int j = 0; j < player->GetPlayerRuntimeData().objectives[i].objective->numTargets; j++) {
+					if (a_questTarget->unk00 == (uint64_t)player->GetPlayerRuntimeData().objectives[i].objective->targets[j]) {
+						quest = player->GetPlayerRuntimeData().objectives[i].objective->ownerQuest;
+						objective = player->GetPlayerRuntimeData().objectives[i];
 						target = (RE::TESQuestTarget*)a_questTarget->unk00;
 						break;
 					}

--- a/source/Hooks.cpp
+++ b/source/Hooks.cpp
@@ -10,24 +10,27 @@ namespace hooks
 							RE::NiPoint3* a_pos, const RE::RefHandle& a_refHandle, std::uint32_t a_markerGotoFrame,
 		RE::TESQuestTarget* a_questTarget)
 	{
+		//
 		if (HUDMarkerManager::AddMarker(a_hudMarkerManager, a_markerData, a_pos, a_refHandle, a_markerGotoFrame))
 		{
 			RE::TESObjectREFR* marker = RE::TESObjectREFR::LookupByHandle(a_refHandle).get();
 
 			RE::PlayerCharacter* player = RE::PlayerCharacter::GetSingleton();
-			RE::TESQuest* a_quest;
-			RE::BGSInstancedQuestObjective a_objective;
+			RE::TESQuest* quest;
+			RE::BGSInstancedQuestObjective objective;
+			RE::TESQuestTarget* target;
 			for (int i = 0; i < player->objectives.size(); i++) {
 				for (int j = 0; j < player->objectives[i].objective->numTargets; j++) {
 					if (a_questTarget->unk00 == (uint64_t)player->objectives[i].objective->targets[j]) {
-						a_quest = player->objectives[i].objective->ownerQuest;
-						a_objective = player->objectives[i];
+						quest = player->objectives[i].objective->ownerQuest;
+						objective = player->objectives[i];
+						target = (RE::TESQuestTarget*)a_questTarget->unk00;
 						break;
 					}
 				}
 			}
 
-			extended::HUDMarkerManager::GetSingleton()->ProcessQuestMarker(a_quest, a_objective, marker, a_markerGotoFrame);
+			extended::HUDMarkerManager::GetSingleton()->ProcessQuestMarker(quest, objective, target, marker, a_markerGotoFrame);
 
 			return true;
 		}

--- a/source/Hooks.cpp
+++ b/source/Hooks.cpp
@@ -8,13 +8,26 @@ namespace hooks
 {
 	bool UpdateQuests(const RE::HUDMarkerManager* a_hudMarkerManager, RE::HUDMarker::ScaleformData* a_markerData,
 							RE::NiPoint3* a_pos, const RE::RefHandle& a_refHandle, std::uint32_t a_markerGotoFrame,
-							RE::TESQuest*& a_quest)
+		RE::TESQuestTarget* a_questTarget)
 	{
 		if (HUDMarkerManager::AddMarker(a_hudMarkerManager, a_markerData, a_pos, a_refHandle, a_markerGotoFrame))
 		{
 			RE::TESObjectREFR* marker = RE::TESObjectREFR::LookupByHandle(a_refHandle).get();
 
-			extended::HUDMarkerManager::GetSingleton()->ProcessQuestMarker(a_quest, marker, a_markerGotoFrame);
+			RE::PlayerCharacter* player = RE::PlayerCharacter::GetSingleton();
+			RE::TESQuest* a_quest;
+			RE::BGSInstancedQuestObjective a_objective;
+			for (int i = 0; i < player->objectives.size(); i++) {
+				for (int j = 0; j < player->objectives[i].objective->numTargets; j++) {
+					if (a_questTarget->unk00 == (uint64_t)player->objectives[i].objective->targets[j]) {
+						a_quest = player->objectives[i].objective->ownerQuest;
+						a_objective = player->objectives[i];
+						break;
+					}
+				}
+			}
+
+			extended::HUDMarkerManager::GetSingleton()->ProcessQuestMarker(a_quest, a_objective, marker, a_markerGotoFrame);
 
 			return true;
 		}


### PR DESCRIPTION
Currently, markers from quests with multiple objectives will usually display the wrong objective text. In reverse-engineering Skyrim's executable, I found that the `rbx` register contains a `TESQuestTarget *` in the same scope that the current code pulls out a `TESQuest *`. Through a slightly roundabout method, (`TESQuestTarget` is a very strange data type) we can deduce which `BGSInstancedQuestObjective`s should be associated with each marker, and thus can show the correct objective text on every marker, even markers pointing to teleport doors behind which lay multiple objectives. Note that it will still only display one quest's objectives at a time, due to the current implementation of `HUDMarkerManager::SetMarkersExtraInfo()`.