### PR TITLE
Compatibility with NPCs Names Distributor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ set(headers
 	include/FocusedMarker.h
 	include/Hooks.h
 	include/HUDMarkerManager.h
+	include/NND_API.h
+	include/NPCNameProvider.h
 	include/pch.h
 	include/QuestItemList.h
 	include/Settings.h
@@ -60,6 +62,7 @@ set(sources
 	source/HUDMarkerManager.cpp
 	source/main.cpp
 	source/MessageListeners.cpp
+	source/NPCNameProvider.cpp
 	source/pch.cpp
 	source/Settings.cpp
 )

--- a/include/FocusedMarker.h
+++ b/include/FocusedMarker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "NPCNameProvider.h"
 #include "utils/Geometry.h"
 
 #include "Settings.h"
@@ -93,7 +94,7 @@ struct FocusedMarker
 		const RE::Character* enemy;
 
 		// cache
-		std::string enemyName = enemy->GetName();
+		std::string enemyName = NPCNameProvider::GetSingleton()->GetName(enemy);
 	};
 
 	struct PlayerSetData : Data

--- a/include/NND_API.h
+++ b/include/NND_API.h
@@ -1,0 +1,60 @@
+
+#pragma once
+
+/*
+* For modders: Copy this file into your own project if you wish to use this API
+*/
+namespace NND_API
+{
+	constexpr auto NNDPluginName = "NPCsNamesDistributor";
+
+	// Available NND interface versions
+	enum class InterfaceVersion : uint8_t
+	{
+		kV1
+	};
+
+	enum class NameContext : uint8_t
+	{
+		kCrosshair = 1,
+		kCrosshairMinion,
+
+		kSubtitles,
+		kDialogue,
+
+		kInventory,
+
+		kBarter,
+
+		kEnemyHUD,
+
+		kOther
+	};
+
+	// NND's modder interface
+	class IVNND1
+	{
+	public:
+		virtual std::string_view GetName(RE::ActorHandle, NameContext) noexcept = 0;
+		virtual std::string_view GetName(const RE::Actor*, NameContext) noexcept = 0;
+		virtual void RevealName(RE::ActorHandle) noexcept = 0;
+		virtual void RevealName(RE::Actor*) noexcept = 0;
+	};
+
+	typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);
+
+	/// <summary>
+	/// Request the NND API interface.
+	/// Recommended: Send your request during or after SKSEMessagingInterface::kMessage_PostLoad to make sure the dll has already been loaded
+	/// </summary>
+	/// <param name="a_interfaceVersion">The interface version to request</param>
+	/// <returns>The pointer to the API singleton, or nullptr if request failed</returns>
+	[[nodiscard]] inline void* RequestPluginAPI(const InterfaceVersion a_interfaceVersion = InterfaceVersion::kV1)
+	{
+		const auto pluginHandle = GetModuleHandle(reinterpret_cast<LPCWSTR>("NPCsNamesDistributor.dll"));
+		if (const _RequestPluginAPI requestAPIFunction = reinterpret_cast<_RequestPluginAPI>(GetProcAddress(pluginHandle, "RequestPluginAPI"))) {
+			return requestAPIFunction(a_interfaceVersion);
+		}
+		return nullptr;
+	}
+}

--- a/include/NND_API.h
+++ b/include/NND_API.h
@@ -35,10 +35,38 @@ namespace NND_API
 	class IVNND1
 	{
 	public:
-		virtual std::string_view GetName(RE::ActorHandle, NameContext) noexcept = 0;
-		virtual std::string_view GetName(const RE::Actor*, NameContext) noexcept = 0;
-		virtual void RevealName(RE::ActorHandle) noexcept = 0;
-		virtual void RevealName(RE::Actor*) noexcept = 0;
+
+		/// <summary>
+		/// Retrieves a generated name for given actor appropriate in specified context.
+		/// Note that NND might not have a name for the actor. In this case an empty string will be returned.
+		/// </summary>
+		/// <param name="actor">Actor for which the name should be retrieved.</param>
+		/// <param name="context">Context in which the name needs to be displayed. Depending on context name might either shortened or formatted differently.</param>
+		/// <returns>A name generated for the actor. If actor does not support generated names an empty string will be returned instead.</returns>
+		virtual std::string_view GetName(RE::ActorHandle actor, NameContext context) noexcept = 0;
+
+		/// <summary>
+		/// Retrieves a generated name for given actor appropriate in specified context.
+		/// Note that NND might not have a name for the actor. In this case an empty string will be returned.
+		/// </summary>
+		/// <param name="actor">Actor for which the name should be retrieved.</param>
+		/// <param name="context">Context in which the name needs to be displayed. Depending on context name might either shortened or formatted differently.</param>
+		/// <returns>A name generated for the actor. If actor does not support generated names an empty string will be returned instead.</returns>
+		virtual std::string_view GetName(const RE::Actor* actor, NameContext context) noexcept = 0;
+
+		/// <summary>
+		/// Reveals a real name of the given actor to the player. If player already knows actor's name this method does nothing.
+		/// This method can be used to programatically introduce an actor to the player.
+		/// </summary>
+		/// <param name="actor">Actor whose name should be revealed.</param>
+		virtual void RevealName(RE::ActorHandle actor) noexcept = 0;
+
+		/// <summary>
+		/// Reveals a real name of the given actor to the player. If player already knows actor's name this method does nothing.
+		/// This method can be used to programatically introduce an actor to the player.
+		/// </summary>
+		/// <param name="actor">Actor whose name should be revealed.</param>
+		virtual void RevealName(RE::Actor* actor) noexcept = 0;
 	};
 
 	typedef void* (*_RequestPluginAPI)(const InterfaceVersion interfaceVersion);

--- a/include/NPCNameProvider.h
+++ b/include/NPCNameProvider.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "NND_API.h"
+
+class NPCNameProvider
+{
+public:
+	static NPCNameProvider* GetSingleton()
+	{
+		static NPCNameProvider singleton;
+		return std::addressof(singleton);
+	}
+
+	const char* GetName(const RE::Actor* actor) const;
+
+	void RequestAPI();
+
+private:
+	NND_API::IVNND1* NND = nullptr;
+
+	NPCNameProvider() = default;
+	NPCNameProvider(const NPCNameProvider&) = delete;
+	NPCNameProvider(NPCNameProvider&&) = delete;
+
+	~NPCNameProvider() = default;
+
+	NPCNameProvider& operator=(const NPCNameProvider&) = delete;
+	NPCNameProvider& operator=(NPCNameProvider&&) = delete;
+};

--- a/source/FocusedMarker.cpp
+++ b/source/FocusedMarker.cpp
@@ -1,5 +1,6 @@
 #include "FocusedMarker.h"
 
+#include "NPCNameProvider.h"
 #include "RE/H/HUDMarkerManager.h"
 
 FocusedMarker::QuestData::QuestData(std::uint32_t a_gfxIndex, std::uint32_t a_gfxGotoFrame, RE::TESObjectREFR* a_marker,
@@ -33,9 +34,9 @@ FocusedMarker::QuestData::QuestData(std::uint32_t a_gfxIndex, std::uint32_t a_gf
 		}
 	case RE::FormType::ActorCharacter:
 		{
-			if (auto character = a_marker->As<RE::Character>())
+			if (auto character = a_marker->As<RE::Character>(); character)
 			{
-				characterName = character->GetName();
+				characterName = NPCNameProvider::GetSingleton()->GetName(character);
 			}
 			break;
 		}

--- a/source/MessageListeners.cpp
+++ b/source/MessageListeners.cpp
@@ -3,6 +3,7 @@
 #include "IUI/API.h"
 
 #include "Compass.h"
+#include "NPCNameProvider.h"
 #include "QuestItemList.h"
 #include "Test.h"
 
@@ -24,6 +25,8 @@ void SKSEMessageListener(SKSE::MessagingInterface::Message* a_msg)
 		{
 			logger::error("Infinity UI installation not detected. Please, go to ... to get it");
 		}
+
+		NPCNameProvider::GetSingleton()->RequestAPI();
 	}
 }
 

--- a/source/NPCNameProvider.cpp
+++ b/source/NPCNameProvider.cpp
@@ -1,0 +1,25 @@
+#include "NPCNameProvider.h"
+#include "NND_API.h"
+
+namespace logger = SKSE::log;
+
+const char* NPCNameProvider::GetName(const RE::Actor* actor) const
+{
+	if (NND) {
+		return NND->GetName(actor, NND_API::NameContext::kEnemyHUD).data();
+	}
+
+	return actor->GetName();
+}
+
+void NPCNameProvider::RequestAPI()
+{
+	if (!NND) {
+		NND = static_cast<NND_API::IVNND1*>(NND_API::RequestPluginAPI(NND_API::InterfaceVersion::kV1));
+		if (NND) {
+			logger::info("Obtained NND API - {0:x}", reinterpret_cast<uintptr_t>(NND));
+		} else {
+			logger::warn("Failed to obtain NND API");
+		}
+	}
+}

--- a/source/NPCNameProvider.cpp
+++ b/source/NPCNameProvider.cpp
@@ -6,7 +6,9 @@ namespace logger = SKSE::log;
 const char* NPCNameProvider::GetName(const RE::Actor* actor) const
 {
 	if (NND) {
-		return NND->GetName(actor, NND_API::NameContext::kEnemyHUD).data();
+		if (auto name = NND->GetName(actor, NND_API::NameContext::kEnemyHUD); !name.empty()) {
+			return name.data();
+		}
 	}
 
 	return actor->GetName();


### PR DESCRIPTION
Hello 🙂 I was made aware of an incompatibility with [NPCs Names Distributor](https://www.nexusmods.com/skyrimspecialedition/mods/73081), where **CNO** ignored generated names and always displayed default ones.

With this change I introduced **NND** API and an `NPCNameProvider` that will try to use that API if present, otherwise it falls back to `actor->GetName()` as it was before.

Please, let me know if you have any concerns with this PR.

> Note: I wasn't able to test this code specifically in CNO because the CNO built from sources kept crashing on launch and I couldn't figure out why, would be great if you could help me fix the project, or check it on your side. But this PR is almost the exact copy of https://github.com/ersh1/TrueHUD/pull/4, which I tested successfully 🙂 