### PR TITLE
use Display Name instead of Name for enemy markers

### DIFF
--- a/include/FocusedMarker.h
+++ b/include/FocusedMarker.h
@@ -76,11 +76,11 @@ struct FocusedMarker
 
 	struct EnemyData : Data
 	{
-		EnemyData(std::uint32_t a_gfxIndex, std::uint32_t a_gfxGotoFrame, const RE::Character* a_enemy) :
+		EnemyData(std::uint32_t a_gfxIndex, std::uint32_t a_gfxGotoFrame, RE::Character* a_enemy) :
 			Data{ a_gfxIndex, a_gfxGotoFrame }, enemy{ a_enemy }
 		{}
 
-		const RE::Character* enemy;
+		RE::Character* enemy;
 
 		// cache
 		std::string enemyName = NPCNameProvider::GetSingleton()->GetName(enemy);

--- a/include/NPCNameProvider.h
+++ b/include/NPCNameProvider.h
@@ -10,7 +10,7 @@ public:
 		return std::addressof(singleton);
 	}
 
-	const char* GetName(const RE::Actor* actor) const;
+	const char* GetName(RE::Actor* actor) const;
 
 	void RequestAPI();
 

--- a/source/NPCNameProvider.cpp
+++ b/source/NPCNameProvider.cpp
@@ -3,7 +3,7 @@
 
 namespace logger = SKSE::log;
 
-const char* NPCNameProvider::GetName(const RE::Actor* actor) const
+const char* NPCNameProvider::GetName(RE::Actor* actor) const
 {
 	if (NND) {
 		if (auto name = NND->GetName(actor, NND_API::NameContext::kEnemyHUD); !name.empty()) {
@@ -11,7 +11,7 @@ const char* NPCNameProvider::GetName(const RE::Actor* actor) const
 		}
 	}
 
-	return actor->GetName();
+	return actor->GetDisplayFullName();
 }
 
 void NPCNameProvider::RequestAPI()


### PR DESCRIPTION
For better compatibility with mods like my [Real Names - Extended](https://www.nexusmods.com/skyrimspecialedition/mods/77038)

I had to remove the `const` from a few places that use this function, since `TESObjectREFR::GetDisplayFullName` isn't const for whatever reason.